### PR TITLE
Add missing docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,13 +8,16 @@
 
 #![doc = include_str!("../README.md")]
 
+/// Core byte container types and traits.
 pub mod bytes;
 mod sources;
 
 #[cfg(feature = "zerocopy")]
+/// Types for zero-copy viewing of structured data.
 pub mod view;
 
 #[cfg(feature = "pyo3")]
+/// Python bindings for [`Bytes`].
 pub mod pybytes;
 
 #[cfg(test)]

--- a/src/pybytes.rs
+++ b/src/pybytes.rs
@@ -11,6 +11,7 @@ use std::os::raw::c_int;
 
 use crate::Bytes;
 
+/// Python wrapper around [`Bytes`].
 #[pyclass(name = "Bytes")]
 pub struct PyBytes {
     bytes: Bytes,
@@ -18,6 +19,11 @@ pub struct PyBytes {
 
 #[pymethods]
 impl PyBytes {
+    /// Exposes the bytes to Python's buffer protocol.
+    ///
+    /// # Safety
+    /// This follows the semantics of the CPython `__getbuffer__` hook and is
+    /// therefore unsafe.
     unsafe fn __getbuffer__(
         slf: PyRefMut<Self>,
         view: *mut ffi::Py_buffer,


### PR DESCRIPTION
## Summary
- document ByteSource and ByteOwner traits
- document `from_raw_parts` for `Bytes`
- add module docs in `lib.rs`
- document `PyBytes` and its buffer protocol method
- document view related APIs and errors
- clarify ByteSource safety invariants

## Testing
- `cargo test --quiet`
- `cargo rustdoc --lib -- -D missing-docs`
- `./scripts/preflight.sh` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6855c5f863588322ae4a63ea2d8a0d8d