### PR TITLE
Add README features section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ and is implemented for a variety of sources already,
 including other byte handling crates `Bytes`, mmap-ed files,
 `String`s and `Zerocopy` types.
 
+## Features
+
+By default the crate enables the `mmap` and `zerocopy` features.
+Other optional features provide additional integrations:
+
+- `bytes` &ndash; support for the [`bytes`](https://crates.io/crates/bytes) crate so `bytes::Bytes` can act as a `ByteSource`.
+- `ownedbytes` &ndash; adds compatibility with [`ownedbytes`](https://crates.io/crates/ownedbytes) and implements its `StableDeref` trait.
+- `mmap` &ndash; enables memory-mapped file handling via the `memmap2` crate.
+- `zerocopy` &ndash; exposes the [`view`](src/view.rs) module for typed zero-copy access and allows using `zerocopy` types as sources.
+- `pyo3` &ndash; builds the [`pybytes`](src/pybytes.rs) module to provide Python bindings for `Bytes`.
+
 ## Comparison
 
 | Crate | Active | Extensible | mmap support | Zerocopy Integration | Pyo3 Integration | kani verified |


### PR DESCRIPTION
## Summary
- document optional crate features and link to related modules

## Testing
- `cargo test`
- `./scripts/preflight.sh` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68582218810883229a48664c4cb0881b