### PR TITLE
Improve crate documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,6 @@
 ## Unreleased
 - limit Kani loop unwind by default and set per-harness bounds
 - increase unwind for prefix/suffix overflow proofs
+- move weak reference and downcasting examples into module docs
+- expand module introduction describing use cases
+- document rationale for separating `ByteSource` and `ByteOwner`


### PR DESCRIPTION
## Summary
- move weak reference example from README to the `bytes` module
- remove README section about downcasting and weak refs
- note documentation move in `CHANGELOG.md`
- expand module introduction describing use cases
- document rationale for separating `ByteSource` and `ByteOwner`

## Testing
- `cargo test --all-features`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68690f0520408322807a47411a8ff045