### PR TITLE
Add code examples and PyBytes demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,5 @@
 - move weak reference and downcasting examples into module docs
 - expand module introduction describing use cases
 - document rationale for separating `ByteSource` and `ByteOwner`
+- add examples for quick start and PyBytes usage
+- add example showing how to wrap Python `bytes` into `Bytes`

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ fn main() {
 }
 ```
 
+The full example is available in [`examples/quick_start.rs`](examples/quick_start.rs).
+
 ## Features
 
 By default the crate enables the `mmap` and `zerocopy` features.
@@ -41,6 +43,12 @@ Other optional features provide additional integrations:
 - `mmap` &ndash; enables memory-mapped file handling via the `memmap2` crate.
 - `zerocopy` &ndash; exposes the [`view`](src/view.rs) module for typed zero-copy access and allows using `zerocopy` types as sources.
 - `pyo3` &ndash; builds the [`pybytes`](src/pybytes.rs) module to provide Python bindings for `Bytes`.
+
+## Examples
+
+- [`examples/quick_start.rs`](examples/quick_start.rs) – the quick start shown above
+- [`examples/pybytes.rs`](examples/pybytes.rs) – demonstrates the `pyo3` feature using `PyBytes`
+- [`examples/from_python.rs`](examples/from_python.rs) – wrap a Python `bytes` object into `Bytes`
 
 ## Comparison
 

--- a/examples/from_python.rs
+++ b/examples/from_python.rs
@@ -1,0 +1,11 @@
+use anybytes::Bytes;
+use pyo3::{prelude::*, types::PyBytes};
+
+fn main() -> PyResult<()> {
+    Python::with_gil(|py| {
+        let obj = PyBytes::new(py, &[5u8, 6, 7]);
+        let any = Bytes::from_source(obj);
+        assert_eq!(&*any, &[5, 6, 7]);
+        Ok(())
+    })
+}

--- a/examples/pybytes.rs
+++ b/examples/pybytes.rs
@@ -1,0 +1,15 @@
+use anybytes::{Bytes, PyBytes};
+use pyo3::prelude::*;
+
+fn main() -> PyResult<()> {
+    Python::with_gil(|py| {
+        let bytes = Bytes::from(vec![1u8, 2, 3, 4]);
+        let wrapped = Py::new(py, PyBytes::new(bytes))?;
+
+        let builtins = PyModule::import(py, "builtins")?;
+        let memoryview = builtins.getattr("memoryview")?.call1((wrapped.bind(py),))?;
+        let length: usize = memoryview.getattr("__len__")?.call0()?.extract()?;
+        assert_eq!(length, 4);
+        Ok(())
+    })
+}

--- a/examples/quick_start.rs
+++ b/examples/quick_start.rs
@@ -1,0 +1,13 @@
+use anybytes::Bytes;
+
+fn main() {
+    // create `Bytes` from a vector
+    let bytes = Bytes::from(vec![1u8, 2, 3, 4]);
+
+    // take a zero-copy slice
+    let slice = bytes.slice(1..3);
+
+    // convert it to a typed View
+    let view = slice.view::<[u8]>().unwrap();
+    assert_eq!(&*view, &[2, 3]);
+}

--- a/src/pybytes.rs
+++ b/src/pybytes.rs
@@ -44,3 +44,10 @@ impl PyBytes {
         Ok(())
     }
 }
+
+impl PyBytes {
+    /// Wrap a [`Bytes`] instance for Python exposure.
+    pub fn new(bytes: Bytes) -> Self {
+        Self { bytes }
+    }
+}


### PR DESCRIPTION
## Summary
- include Rust example `examples/quick_start.rs`
- show Python wrapper usage in `examples/pybytes.rs`
- expose a `PyBytes::new` helper
- reference the examples from the README
- add example showing how to wrap Python `bytes` objects

## Testing
- `cargo test --all-features`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_686934af497c8322a243064dca9eafc3