### PR TITLE
Add weak reference tests and view Kani proofs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - move weak reference and downcasting examples into module docs
 - expand module introduction describing use cases
 - document rationale for separating `ByteSource` and `ByteOwner`
+- add tests for weak reference upgrade/downgrade and Kani proofs for view helpers


### PR DESCRIPTION
## Summary
- add WeakBytes and WeakView upgrade tests
- introduce kani harnesses for view_prefix, view_suffix and field_to_view
- document changes in CHANGELOG

## Testing
- `./scripts/devtest.sh`
- `./scripts/preflight.sh` *(failed: Kani verification ran for too long)*

------
https://chatgpt.com/codex/tasks/task_e_686934b67a6083228c411eb8e3007732