### PR TITLE
Document pyo3 requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - added crate-level examples for weak references and owner downcasting
 - expanded module introduction describing use cases
 - documented rationale for separating `ByteSource` and `ByteOwner`
+- note that the `pyo3` feature requires Python development libraries
 
 ## 0.19.3 - 2025-05-30
 - implemented `Error` for `ViewError`

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ Other optional features provide additional integrations:
 - `zerocopy` &ndash; exposes the [`view`](src/view.rs) module for typed zero-copy access and allows using `zerocopy` types as sources.
 - `pyo3` &ndash; builds the [`pybytes`](src/pybytes.rs) module to provide Python bindings for `Bytes`.
 
+Enabling the `pyo3` feature requires the Python development headers and libraries
+(for example `libpython3.x`). Running `cargo test --all-features` therefore
+needs these libraries installed; otherwise disable the feature during testing.
+
 ## Examples
 
 - [`examples/quick_start.rs`](examples/quick_start.rs) – the quick start shown above


### PR DESCRIPTION
## Summary
- note that using the `pyo3` feature needs Python dev headers
- document requirement in changelog

## Testing
- `cargo test --all-features`
- `./scripts/preflight.sh` *(fails: aborted during long Kani verification)*

------
https://chatgpt.com/codex/tasks/task_e_686ac5f7ca3083229d0b609a8ed7687a