### PR TITLE
Document erase_lifetime safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - added crate-level examples for weak references and owner downcasting
 - expanded module introduction describing use cases
 - documented rationale for separating `ByteSource` and `ByteOwner`
+- documented safety requirements for `erase_lifetime`
 
 ## 0.19.3 - 2025-05-30
 - implemented `Error` for `ViewError`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,11 @@ pub use crate::pybytes::PyBytes;
 #[cfg(feature = "zerocopy")]
 pub use crate::view::View;
 
+/// Erase the lifetime of a reference.
+///
+/// # Safety
+/// The caller must guarantee that the referenced data remains valid for the
+/// `'static` lifetime.
 unsafe fn erase_lifetime<'a, T: ?Sized>(slice: &'a T) -> &'static T {
     &*(slice as *const T)
 }


### PR DESCRIPTION
## Summary
- add safety note for `erase_lifetime`
- record change in changelog

## Testing
- `cargo test --all-features`
- `./scripts/preflight.sh` *(failed: aborting on Kani verification)*

------
https://chatgpt.com/codex/tasks/task_e_686ac6128fc88322b21d23131d211954