### PR TITLE
Update preflight rustfmt check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - added crate-level examples for weak references and owner downcasting
 - expanded module introduction describing use cases
 - documented rationale for separating `ByteSource` and `ByteOwner`
+- verify `cargo fmt` availability and install `rustfmt` via rustup if missing
 
 ## 0.19.3 - 2025-05-30
 - implemented `Error` for `ViewError`

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 # Ensure required tools are available
-if ! command -v rustfmt >/dev/null 2>&1; then
-  echo "rustfmt not found. Installing via rustup..."
+if ! cargo fmt --version >/dev/null 2>&1; then
+  echo "cargo fmt not found. Installing rustfmt via rustup..."
   rustup component add rustfmt
 fi
 


### PR DESCRIPTION
## Summary
- ensure `scripts/preflight.sh` verifies `cargo fmt` and installs the `rustfmt` component via `rustup` if missing
- document the new check in `CHANGELOG`

## Testing
- `cargo test --all-features`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_686ac5dbe0d88322ba69a9fe7ed18075