### PR TITLE
Bump bytes-related deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - clarify library overview and development instructions in README
 - added crate-level examples for weak references and owner downcasting
 - expanded module introduction describing use cases
+- update bytes, ownedbytes, memmap2, zerocopy and pyo3 dependencies
 - documented rationale for separating `ByteSource` and `ByteOwner`
 
 ## 0.19.3 - 2025-05-30

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,11 @@ repository = "https://github.com/triblespace/anybytes"
 description = "A small library abstracting over bytes owning types in an extensible way."
 
 [dependencies]
-bytes = { version = "1.6.0", optional = true }
-ownedbytes = { version = "0.7.0", optional = true }
-memmap2 = { version = "0.9.4", optional = true }
-zerocopy = { version = "0.8.14", optional = true, features = ["derive"] }
-pyo3 = {version = "0.23.1", optional = true }
+bytes = { version = "1.10.1", optional = true }
+ownedbytes = { version = "0.9.0", optional = true }
+memmap2 = { version = "0.9.5", optional = true }
+zerocopy = { version = "0.8.26", optional = true, features = ["derive"] }
+pyo3 = { version = "0.25.1", optional = true }
 
 [dev-dependencies]
 quickcheck = "1.0"


### PR DESCRIPTION
## Summary
- bump versions of bytes, ownedbytes, memmap2, zerocopy and pyo3
- update changelog entry

## Testing
- `cargo test --lib --tests`
- `./scripts/preflight.sh` *(fails: aborting on `assume(false)` from Kani)*

------
https://chatgpt.com/codex/tasks/task_e_686ac62f880c83229f069c48d174638f