### PR TITLE
Switch property tests to proptest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - verify `cargo fmt` availability and install `rustfmt` via rustup if missing
 - note that the `pyo3` feature requires Python development libraries
 - documented safety requirements for `erase_lifetime`
+- replaced `quickcheck` property tests with `proptest`
 
 ## 0.19.3 - 2025-05-30
 - implemented `Error` for `ViewError`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ zerocopy = { version = "0.8.26", optional = true, features = ["derive"] }
 pyo3 = { version = "0.25.1", optional = true }
 
 [dev-dependencies]
-quickcheck = "1.0"
+proptest = "1.7"
 
 [features]
 default = ["mmap", "zerocopy"]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -6,21 +6,25 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use quickcheck::quickcheck;
+use proptest::prelude::*;
 
 use crate::Bytes;
 
-quickcheck! {
-    fn test_shallow_clone(v: Vec<u8>) -> bool {
+proptest! {
+    #[test]
+    fn test_shallow_clone(v in proptest::collection::vec(any::<u8>(), 0..256)) {
         let a: Bytes = v.into();
         let b: Bytes = a.clone();
-        a == b && a.as_ptr() == b.as_ptr()
+        prop_assert_eq!(a.as_ref(), b.as_ref());
+        prop_assert_eq!(a.as_ptr(), b.as_ptr());
     }
 
-    fn test_shallow_slice(v: Vec<u8>) -> bool {
+    #[test]
+    fn test_shallow_slice(v in proptest::collection::vec(any::<u8>(), 0..256)) {
         let a: Bytes = v.into();
         let b: Bytes = a.slice(..a.len() / 2);
-        &b[..] == &a[..b.len()] && (b.is_empty() || a.as_ptr() == b.as_ptr())
+        prop_assert_eq!(&b[..], &a[..b.len()]);
+        prop_assert!(b.is_empty() || a.as_ptr() == b.as_ptr());
     }
 }
 


### PR DESCRIPTION
## Summary
- replace `quickcheck` with `proptest`
- update tests to use `proptest!` macro
- note change in `CHANGELOG`

## Testing
- `cargo test --all-features`
- `./scripts/preflight.sh` *(fails: Kani verification aborts)*

------
https://chatgpt.com/codex/tasks/task_e_686da4e0ec7c8322b278662a8027b1df