### PR TITLE
Implement Clone and Debug for weak refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - verify `cargo fmt` availability and install `rustfmt` via rustup if missing
 - note that the `pyo3` feature requires Python development libraries
 - documented safety requirements for `erase_lifetime`
+- derive `Clone` and `Debug` for `WeakBytes` and `WeakView`
 
 ## 0.19.3 - 2025-05-30
 - implemented `Error` for `ViewError`

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -127,6 +127,7 @@ pub struct Bytes {
 ///
 /// The referenced subrange of the [Bytes] is reconstructed
 /// on [WeakBytes::upgrade].
+#[derive(Clone, Debug)]
 pub struct WeakBytes {
     data: *const [u8],
     owner: Weak<dyn ByteOwner>,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -98,6 +98,22 @@ fn test_weakbytes_multiple_upgrades() {
     assert!(weak.upgrade().is_none());
 }
 
+#[test]
+fn test_weakbytes_clone_upgrade() {
+    let bytes = Bytes::from(b"hello".to_vec());
+    let weak = bytes.downgrade();
+    let weak_clone = weak.clone();
+
+    let strong = weak_clone.upgrade().unwrap();
+    assert_eq!(strong.as_ref(), bytes.as_ref());
+
+    drop(bytes);
+    drop(strong);
+
+    assert!(weak.upgrade().is_none());
+    assert!(weak_clone.upgrade().is_none());
+}
+
 #[cfg(feature = "zerocopy")]
 #[test]
 fn test_weakview_downgrade_upgrade() {
@@ -113,4 +129,24 @@ fn test_weakview_downgrade_upgrade() {
     drop(strong);
 
     assert!(weak.upgrade().is_none());
+}
+
+#[cfg(feature = "zerocopy")]
+#[test]
+fn test_weakview_clone_upgrade() {
+    let bytes = Bytes::from(b"abcdef".to_vec());
+    let view = bytes.clone().view::<[u8]>().unwrap();
+
+    let weak = view.downgrade();
+    let weak_clone = weak.clone();
+
+    let strong = weak_clone.upgrade().unwrap();
+    assert_eq!(strong.as_ref(), view.as_ref());
+
+    drop(bytes);
+    drop(view);
+    drop(strong);
+
+    assert!(weak.upgrade().is_none());
+    assert!(weak_clone.upgrade().is_none());
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -185,6 +185,23 @@ pub struct WeakView<T: Immutable + ?Sized + 'static> {
     pub(crate) owner: Weak<dyn ByteOwner>,
 }
 
+impl<T: ?Sized + Immutable> Clone for WeakView<T> {
+    fn clone(&self) -> Self {
+        Self {
+            data: self.data,
+            owner: self.owner.clone(),
+        }
+    }
+}
+
+impl<T: ?Sized + Immutable> Debug for WeakView<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WeakView")
+            .field("data", &self.data)
+            .finish_non_exhaustive()
+    }
+}
+
 // ByteOwner is Send + Sync and View is immutable.
 unsafe impl<T: ?Sized + Immutable> Send for View<T> {}
 unsafe impl<T: ?Sized + Immutable> Sync for View<T> {}


### PR DESCRIPTION
## Summary
- implement `Clone` and `Debug` for `WeakBytes`
- provide manual `Clone`/`Debug` impls for `WeakView<T>`
- test cloning of weak references for both bytes and views
- note new implementations in the changelog

## Testing
- `cargo test --all-features`
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_686da39bc6b48322909f778b45fc4ed9