### PR TITLE
Separate Kani verification script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,11 +14,12 @@ The project balances a few key goals:
 * Run `cargo fmt` on any Rust files you modify.
 * Run `cargo test` and ensure it passes before committing. If tests fail or cannot run, note that in your PR.
 * For quick iterations, run `./scripts/devtest.sh` to execute only the tests.
-* Before committing, execute `./scripts/preflight.sh` from the repository root. This script runs formatting checks, tests, and Kani verification. Ensure `rustfmt` and the Kani verifier are installed separately. If Kani fails for reasons unrelated to your change, mention it in the PR.
+* Before committing, execute `./scripts/preflight.sh` from the repository root. This script runs formatting checks and tests. Kani proofs run separately via `./scripts/verify.sh`, which normally shouldn't be executed locally and is intended for a dedicated system.
 * Avoid committing files in `target/` or other build artifacts listed in `.gitignore`.
 * Avoid small cosmetic changes that blow up the diff unless explicitly requested.
 * Use clear commit messages describing the change.
 * Add an entry to `CHANGELOG.md` summarizing your task.
+* Avoid writing asynchronous code. Prefer high-performance synchronous implementations that can be parallelized when needed.
 
 ## Pull Request Notes
 
@@ -34,22 +35,16 @@ The assistant's internet access is intentionally limited for their own safety to
 
 Codex is encouraged to share opinions on how to improve the project. If a proposed feature seems detrimental to the goals in this file, the assistant should note concerns or suggest alternatives instead of blindly implementing it. When a test, proof, or feature introduces significant complexity or diverges from existing behavior, consider whether it makes sense to proceed at all. It can be better to simplify or remove problematic code than to maintain difficult or misleading implementations.
 
+
 ## Proof Best Practices
 
 Kani verification can be expensive. To keep proof times manageable:
 
 * Write focused harnesses that verify one small property.
 * Use bounded loops and avoid unbounded recursion.
-* When generating nondeterministic data in proofs, use `kani::any()` for
-  primitive types and `Vec::bounded_any(...)`/`String::bounded_any(...)` for
-  collections. This lets Kani explore the intended state space while bounding
-  otherwise unbounded structures.
-* Avoid using fixed constants in Kani proofs. Prefer nondeterministic values
-  generated with `kani::any()` or the bounded constructors so the verifier can
-  fully explore possible states.
+* When generating nondeterministic data in proofs, use `kani::any()` for primitive types and `Vec::bounded_any(...)`/`String::bounded_any(...)` for collections. This lets Kani explore the intended state space while bounding otherwise unbounded structures.
+* Avoid using fixed constants in Kani proofs. Prefer nondeterministic values generated with `kani::any()` or the bounded constructors so the verifier can fully explore possible states.
 * Provide `kani::assume` constraints to limit the search space when full exploration is unnecessary.
 * Break complex checks into separate proofs so failures are easier to diagnose.
-* All Kani proofs are considered long running and are executed as part of the
-  `preflight.sh` script or in CI.
-* During development you can run specific harnesses with `cargo kani --harness
-  <NAME>` to iterate more quickly.
+* All Kani proofs are considered long running and are executed via `verify.sh` or in CI.
+* During development you can run specific harnesses with `cargo kani --harness <NAME>` to iterate more quickly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- split Kani verification into `verify.sh` and streamline `preflight.sh`
+- clarify that `verify.sh` runs on a dedicated system and document avoiding async code
+- install `rustfmt` and the Kani verifier automatically via `cargo install`
+- restore Kani proof best practices in `AGENTS.md` and note that proofs run via `verify.sh`
 - limit Kani loop unwind by default and set per-harness bounds
 - increase unwind for prefix/suffix overflow proofs
 - move weak reference and downcasting examples into module docs

--- a/README.md
+++ b/README.md
@@ -98,8 +98,14 @@ needs these libraries installed; otherwise disable the feature during testing.
 
 ## Development
 
-Run `./scripts/preflight.sh` from the repository root before committing.  The
-script formats the code, executes all tests, and verifies the Kani proofs.
+Run `./scripts/preflight.sh` from the repository root before committing. The
+script formats the code and executes all tests, automatically installing required
+tools if needed.
+
+Kani proofs are executed separately with `./scripts/verify.sh`, which should be
+run on a dedicated system. The script will install the Kani verifier
+automatically. Verification can take a long time and isn't needed for quick
+development iterations.
 
 ## Glossary
 

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -5,17 +5,10 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 # Ensure required tools are available
-if ! cargo fmt --version >/dev/null 2>&1; then
-  echo "cargo fmt not found. Installing rustfmt via rustup..."
-  rustup component add rustfmt
-fi
+# Install rustfmt unconditionally. The command is idempotent and will
+# skip installation if the tool is already available.
+cargo install rustfmt || true
 
-if ! cargo kani --version >/dev/null 2>&1; then
-  echo "cargo-kani not found. Installing Kani verifier..."
-  cargo install --locked kani-verifier
-fi
-
-# Run formatting check, tests, and Kani verification
+# Run formatting check and tests
 cargo fmt -- --check
 cargo test --all-features
-cargo kani --workspace --all-features

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Move to repository root
+cd "$(dirname "$0")/.."
+
+# Ensure required tools are available
+# Install rustfmt. The command is idempotent so we simply ignore failures.
+cargo install rustfmt || true
+
+# Install the Kani verifier as needed; this is also idempotent.
+cargo install --locked kani-verifier || true
+
+# Run all Kani proofs in the workspace
+cargo kani --workspace --all-features
+


### PR DESCRIPTION
## Summary
- clarify that verify.sh installs its tools and should run on a dedicated system
- automate installing cargo tools in preflight.sh and verify.sh
- remove install directions from the README
- document tool installation in the changelog
- restore proof best practices in the AGENTS guidelines

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_686ed0657940832298e1b693a990ab51