### PR TITLE
Add INVENTORY tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,13 @@ The project balances a few key goals:
 * Add an entry to `CHANGELOG.md` summarizing your task.
 * Avoid writing asynchronous code. Prefer high-performance synchronous implementations that can be parallelized when needed.
 
+## Inventory
+
+Record future work and ideas in `INVENTORY.md`. Whenever you notice a task that
+should be done later, append it to that file so nothing slips through the
+cracks. Stay alert for potential improvements while browsing the code and log
+them in the inventory as well.
+
 ## Pull Request Notes
 
 When opening a PR, include a short summary of what changed and reference relevant file sections.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - move weak reference and downcasting examples into module docs
 - expand module introduction describing use cases
 - document rationale for separating `ByteSource` and `ByteOwner`
+- added `INVENTORY.md` for tracking future work and noted it in `AGENTS.md`
+- removed the Completed Work section from `INVENTORY.md` and documented its use
+  in a dedicated AGENTS section
 - add tests for weak reference upgrade/downgrade and Kani proofs for view helpers
 - add examples for quick start and PyBytes usage
 - add example showing how to wrap Python `bytes` into `Bytes`

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -1,0 +1,12 @@
+# Inventory
+
+## Potential Removals
+- None at the moment.
+
+## Desired Functionality
+- Add more ByteSource integrations (e.g. memory mapped arrays, rope-like stores).
+- Provide asynchronous-friendly wrappers without forcing async code in the core.
+- Example showcasing integration with Python via the `pyo3` feature.
+
+## Discovered Issues
+- `ByteOwner` implementations could expose safe methods for reclaiming owned data.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ and is implemented for a variety of sources already,
 including other byte handling crates `Bytes`, mmap-ed files,
 `String`s and `Zerocopy` types.
 
+See `INVENTORY.md` for notes on possible cleanup and future functionality.
+
 ## Overview
 
 `Bytes` decouples data access from lifetime management through two traits:


### PR DESCRIPTION
## Summary
- introduce `INVENTORY.md` to gather future work
- mention the new file in `AGENTS.md`
- record the addition in `CHANGELOG.md`
- document usage of inventory in AGENTS guidelines
- cross-reference inventory from README
- remove the Completed Work section and add dedicated Inventory instructions

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_68759bedc2588322a91f0ecb103a8a63