### PR TITLE
Implement new ByteSource integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 - warn about missing documentation by enabling the `missing_docs` lint
 - derive `Clone` and `Debug` for `WeakBytes` and `WeakView`
 - replaced `quickcheck` property tests with `proptest`
+- added `ByteSource` support for `memmap2::MmapMut` and `Cow<'static, [T]>` with `zerocopy`
+- split `Cow` ByteSource tests into dedicated cases
 
 ## 0.19.3 - 2025-05-30
 - implemented `Error` for `ViewError`

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -4,9 +4,8 @@
 - None at the moment.
 
 ## Desired Functionality
-- Add more ByteSource integrations (e.g. memory mapped arrays, rope-like stores).
+- Add ByteSource integration for rope-like stores.
 - Provide asynchronous-friendly wrappers without forcing async code in the core.
-- Example showcasing integration with Python via the `pyo3` feature.
 
 ## Discovered Issues
 - `ByteOwner` implementations could expose safe methods for reclaiming owned data.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -154,3 +154,57 @@ fn test_weakview_clone_upgrade() {
     assert!(weak.upgrade().is_none());
     assert!(weak_clone.upgrade().is_none());
 }
+
+#[cfg(feature = "mmap")]
+#[test]
+fn test_mmap_mut_source() {
+    let mut mmap = memmap2::MmapMut::map_anon(4).expect("mmap");
+    mmap.copy_from_slice(b"test");
+    let bytes = Bytes::from_source(mmap);
+    assert_eq!(bytes.as_ref(), b"test");
+}
+
+#[test]
+fn test_cow_u8_owned_source() {
+    use std::borrow::Cow;
+
+    let owned: Cow<'static, [u8]> = Cow::Owned(vec![1, 2, 3, 4]);
+    let bytes_owned = Bytes::from_source(owned.clone());
+    assert_eq!(bytes_owned.as_ref(), owned.as_ref());
+}
+
+#[test]
+fn test_cow_u8_borrowed_source() {
+    use std::borrow::Cow;
+
+    let borrowed: Cow<'static, [u8]> = Cow::Borrowed(b"abcd");
+    let bytes_borrowed = Bytes::from_source(borrowed.clone());
+    assert_eq!(bytes_borrowed.as_ref(), borrowed.as_ref());
+}
+
+#[cfg(feature = "zerocopy")]
+#[test]
+fn test_cow_zerocopy_owned_source() {
+    use std::borrow::Cow;
+
+    let owned: Cow<'static, [u32]> = Cow::Owned(vec![1, 2, 3, 4]);
+    let bytes_owned = Bytes::from_source(owned.clone());
+    assert_eq!(
+        bytes_owned.as_ref(),
+        zerocopy::IntoBytes::as_bytes(owned.as_ref())
+    );
+}
+
+#[cfg(feature = "zerocopy")]
+#[test]
+fn test_cow_zerocopy_borrowed_source() {
+    use std::borrow::Cow;
+
+    static BORROWED: [u32; 2] = [5, 6];
+    let borrowed: Cow<'static, [u32]> = Cow::Borrowed(&BORROWED);
+    let bytes_borrowed = Bytes::from_source(borrowed.clone());
+    assert_eq!(
+        bytes_borrowed.as_ref(),
+        zerocopy::IntoBytes::as_bytes(borrowed.as_ref())
+    );
+}


### PR DESCRIPTION
## Summary
- add generic `ByteSource` for `Cow<'static, [T]>` when `zerocopy` is enabled
- keep fallback impl for `Cow<'static, [u8]>`
- implement `ByteSource` for `memmap2::MmapMut`
- split `Cow` integration tests into owned and borrowed cases
- update changelog about the broader support

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_6876e1a5b89c8322abe2ab52178522d3