### PR TITLE
Fix default tests by gating Python examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - replaced `quickcheck` property tests with `proptest`
 - added `ByteSource` support for `memmap2::MmapMut` and `Cow<'static, [T]>` with `zerocopy`
 - split `Cow` ByteSource tests into dedicated cases
+- skip Python examples when the `pyo3` feature is disabled to fix `cargo test`
 
 ## 0.19.3 - 2025-05-30
 - implemented `Error` for `ViewError`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,11 @@ default-unwind = "1"
 
 [workspace.metadata.kani.flags]
 default-unwind = "1"
+
+[[example]]
+name = "from_python"
+required-features = ["pyo3"]
+
+[[example]]
+name = "pybytes"
+required-features = ["pyo3"]


### PR DESCRIPTION
## Summary
- skip Python examples when `pyo3` is disabled so `cargo test` works without Python

## Testing
- `cargo test --quiet`
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_6877cc0ffc2c8322bd211b7154871f70