### PR TITLE
Change downcast_to_owner to return Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - removed the Completed Work section from `INVENTORY.md` and documented its use
 - rewrote `winnow::view` to use safe helpers and added `view_elems(count)` parser
 - `winnow::view_elems` now returns a Parser closure for idiomatic usage
+- `Bytes::downcast_to_owner` and `View::downcast_to_owner` now return `Result`
+  and return the original value on failure
   in a dedicated AGENTS section
 - add tests for weak reference upgrade/downgrade and Kani proofs for view helpers
 - add examples for quick start and PyBytes usage

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -32,10 +32,14 @@ proptest! {
 fn test_downcast() {
     let v = b"abcd".to_vec();
     let b = Bytes::from(v);
-    assert!(b.downcast_to_owner::<Vec<u8>>().is_some());
+    assert!(b.downcast_to_owner::<Vec<u8>>().is_ok());
+
     let v = b"abcd".to_vec();
     let b = Bytes::from(v);
-    assert!(b.downcast_to_owner::<String>().is_none());
+    match b.downcast_to_owner::<String>() {
+        Ok(_) => panic!("unexpected success"),
+        Err(orig) => assert_eq!(orig.as_ref(), b"abcd"),
+    }
 }
 
 #[test]

--- a/src/view.rs
+++ b/src/view.rs
@@ -227,13 +227,15 @@ impl<T: ?Sized + Immutable> View<T> {
     }
 
     /// Returns the owner of the View in an `Arc`.
-    pub fn downcast_to_owner<O>(self) -> Option<Arc<O>>
+    pub fn downcast_to_owner<O>(self) -> Result<Arc<O>, View<T>>
     where
         O: Send + Sync + 'static,
     {
-        let owner = self.owner;
-        let owner = ByteOwner::as_any(owner);
-        owner.downcast::<O>().ok()
+        let owner_any = ByteOwner::as_any(self.owner.clone());
+        match owner_any.downcast::<O>() {
+            Ok(owner) => Ok(owner),
+            Err(_) => Err(self),
+        }
     }
 
     /// Create a weak pointer.


### PR DESCRIPTION
## Summary
- change `Bytes::downcast_to_owner` to return `Result<Arc<T>, Bytes>`
- same change for `View::downcast_to_owner`
- test failure returns the original `Bytes`
- document the updated API and add changelog entry

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_687c1dc2c8d88322a726355f10a3d073