### PR TITLE
Generalize map_file helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@
 - added `ByteSource` support for `memmap2::MmapMut` and `Cow<'static, [T]>` with `zerocopy`
 - split `Cow` ByteSource tests into dedicated cases
 - skip Python examples when the `pyo3` feature is disabled to fix `cargo test`
+- added `Bytes::map_file` helper for convenient file mapping
+  (accepts any `memmap2::MmapAsRawDesc`, e.g. `&File` or `&NamedTempFile`)
 
 ## 0.19.3 - 2025-05-30
 - implemented `Error` for `ViewError`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ winnow = { version = "0.7.12", optional = true }
 
 [dev-dependencies]
 proptest = "1.7"
+tempfile = "3.20"
 
 [features]
 default = ["mmap", "zerocopy"]

--- a/README.md
+++ b/README.md
@@ -60,8 +60,11 @@ use zerocopy::{FromBytes, Immutable, KnownLayout};
 #[repr(C)]
 struct Header { magic: u32, count: u32 }
 
-fn read_header(map: memmap2::Mmap) -> anybytes::view::View<Header> {
-    Bytes::from(map).view().unwrap()
+// `file` can be any type that implements `memmap2::MmapAsRawDesc` such as
+// `&std::fs::File` or `&tempfile::NamedTempFile`.
+fn read_header(file: &std::fs::File) -> std::io::Result<anybytes::view::View<Header>> {
+    let bytes = unsafe { Bytes::map_file(file)? };
+    Ok(bytes.view().unwrap())
 }
 ```
 

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -211,6 +211,26 @@ impl Bytes {
         Self { data, owner: arc }
     }
 
+    /// Memory-map the given file descriptor and return the bytes.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the mapped file is not modified for the
+    /// lifetime of the returned [`Bytes`]. Changing the file contents while it
+    /// is mapped can lead to undefined behavior. The file handle does not need
+    /// to remain open after mapping.
+    ///
+    /// The argument may be any type that implements [`memmap2::MmapAsRawDesc`],
+    /// such as [`&std::fs::File`] or [`&tempfile::NamedTempFile`].
+    #[cfg(feature = "mmap")]
+    pub unsafe fn map_file<F>(file: F) -> std::io::Result<Self>
+    where
+        F: memmap2::MmapAsRawDesc,
+    {
+        let map = memmap2::MmapOptions::new().map(file)?;
+        Ok(Self::from_source(map))
+    }
+
     #[inline]
     pub(crate) fn as_slice<'a>(&'a self) -> &'a [u8] {
         self.data

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -218,6 +218,17 @@ fn test_mmap_mut_source() {
     assert_eq!(bytes.as_ref(), b"test");
 }
 
+#[cfg(feature = "mmap")]
+#[test]
+fn test_map_file() {
+    use std::io::Write;
+    let mut file = tempfile::NamedTempFile::new().expect("temp file");
+    file.write_all(b"testfile").expect("write");
+    file.flush().unwrap();
+    let bytes = unsafe { Bytes::map_file(&file) }.expect("map file");
+    assert_eq!(bytes.as_ref(), b"testfile");
+}
+
 #[test]
 fn test_cow_u8_owned_source() {
     use std::borrow::Cow;


### PR DESCRIPTION
## Summary
- allow `Bytes::map_file` to take any descriptor implementing `MmapAsRawDesc`
- use the generic API in tests and documentation
- document the change in the changelog

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_687e3787d3b883228e22b8d6d116eae5