### PR TITLE
Simplify ByteOwner downcasting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - removed the Completed Work section from `INVENTORY.md` and documented its use
 - rewrote `winnow::view` to use safe helpers and added `view_elems(count)` parser
 - `winnow::view_elems` now returns a Parser closure for idiomatic usage
+- replaced `ByteOwner::as_any` with trait upcasting to `Any`
 - `Bytes::downcast_to_owner` and `View::downcast_to_owner` now return `Result`
   and return the original value on failure
   in a dedicated AGENTS section

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -240,18 +240,10 @@ unsafe impl ByteSource for memmap2::MmapMut {
 }
 
 #[cfg(feature = "mmap")]
-impl ByteOwner for memmap2::MmapRaw {
-    fn as_any(self: std::sync::Arc<Self>) -> std::sync::Arc<dyn std::any::Any + Sync + Send> {
-        self
-    }
-}
+impl ByteOwner for memmap2::MmapRaw {}
 
 #[cfg(feature = "pyo3")]
-impl ByteOwner for pyo3::Py<pyo3::types::PyBytes> {
-    fn as_any(self: std::sync::Arc<Self>) -> std::sync::Arc<dyn std::any::Any + Sync + Send> {
-        self
-    }
-}
+impl ByteOwner for pyo3::Py<pyo3::types::PyBytes> {}
 
 #[cfg(feature = "pyo3")]
 unsafe impl<'py> ByteSource for pyo3::Bound<'py, pyo3::types::PyBytes> {

--- a/src/view.rs
+++ b/src/view.rs
@@ -12,8 +12,9 @@ use std::cmp::Ordering;
 use crate::bytes::is_subslice;
 use crate::erase_lifetime;
 use crate::{bytes::ByteOwner, Bytes};
-use std::sync::Weak;
-use std::{fmt::Debug, hash::Hash, ops::Deref, sync::Arc};
+use std::any::Any;
+use std::sync::{Arc, Weak};
+use std::{fmt::Debug, hash::Hash, ops::Deref};
 use zerocopy::{Immutable, IntoBytes, KnownLayout, TryCastError, TryFromBytes};
 
 /// Errors that can occur when constructing a [`View`].
@@ -231,7 +232,7 @@ impl<T: ?Sized + Immutable> View<T> {
     where
         O: Send + Sync + 'static,
     {
-        let owner_any = ByteOwner::as_any(self.owner.clone());
+        let owner_any: Arc<dyn Any + Send + Sync> = self.owner.clone();
         match owner_any.downcast::<O>() {
             Ok(owner) => Ok(owner),
             Err(_) => Err(self),


### PR DESCRIPTION
## Summary
- replace `ByteOwner::as_any` with trait upcasting
- update downcast helpers to use `Arc<dyn Any>`
- remove empty `as_any` impls
- document the change in the changelog

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_687e6d4517d48322aafb7c21f62caed5