### PR TITLE
Improve ByteOwner docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@
 - skip Python examples when the `pyo3` feature is disabled to fix `cargo test`
 - added `Bytes::map_file` helper for convenient file mapping
   (accepts any `memmap2::MmapAsRawDesc`, e.g. `&File` or `&NamedTempFile`)
+- expanded `ByteOwner` trait docs to clarify lifetime requirements and trait
+  upcasting for downcasting
 
 ## 0.19.3 - 2025-05-30
 - implemented `Error` for `ViewError`

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -97,10 +97,15 @@ pub unsafe trait ByteSource {
 
 /// A trait for types that keep the backing bytes of [`Bytes`] alive.
 ///
+/// Implementors must guarantee that the returned `Arc<dyn ByteOwner>` keeps
+/// the underlying storage valid for as long as that `Arc` is held.  Dropping
+/// the original value must not invalidate any [`Bytes`] or [`View`](crate::view::View)
+/// instances that cloned the owner.
+///
 /// This trait extends [`Any`] so that owners can be downcast directly via
-/// [`Arc::downcast`].  No conversion method is required; callers can simply
-/// upcast the owner `Arc` to `Arc<dyn Any + Send + Sync>` and attempt a
-/// downcast.
+/// [`Arc::downcast`].  Callers can upcast the owner to
+/// `Arc<dyn Any + Send + Sync>` and then attempt a downcast to reclaim the
+/// concrete type.
 pub trait ByteOwner: Any + Sync + Send {}
 
 impl<T: ByteSource + Sync + Send + 'static> ByteOwner for T {}


### PR DESCRIPTION
## Summary
- clarify that ByteOwner implementations must hold backing bytes alive
- mention trait upcasting to `Any` for owner downcasting

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_687ed8280c648322b9c87c26126d4543