### PR TITLE
Add try_unwrap_owner usage example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - skip Python examples when the `pyo3` feature is disabled to fix `cargo test`
 - added `Bytes::map_file` helper for convenient file mapping
   (accepts any `memmap2::MmapAsRawDesc`, e.g. `&File` or `&NamedTempFile`)
+- added README example demonstrating `Bytes::try_unwrap_owner`
 
 ## 0.19.3 - 2025-05-30
 - implemented `Error` for `ViewError`

--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ fn main() {
 
 The full example is available in [`examples/quick_start.rs`](examples/quick_start.rs).
 
+## Reclaiming Ownership
+
+`Bytes::try_unwrap_owner` allows recovering the original owner when no other
+references exist.
+
+```rust
+use anybytes::Bytes;
+
+let bytes = Bytes::from(vec![1u8, 2, 3]);
+let vec = bytes.try_unwrap_owner::<Vec<u8>>().expect("unique owner");
+assert_eq!(vec, vec![1, 2, 3]);
+```
+
 ## Advanced Usage
 
 `Bytes` can directly wrap memory-mapped files or other large buffers.  Combined
@@ -87,6 +100,7 @@ needs these libraries installed; otherwise disable the feature during testing.
 ## Examples
 
 - [`examples/quick_start.rs`](examples/quick_start.rs) – the quick start shown above
+- [`examples/try_unwrap_owner.rs`](examples/try_unwrap_owner.rs) – reclaim the owner when uniquely referenced
 - [`examples/pybytes.rs`](examples/pybytes.rs) – demonstrates the `pyo3` feature using `PyBytes`
 - [`examples/from_python.rs`](examples/from_python.rs) – wrap a Python `bytes` object into `Bytes`
 

--- a/examples/try_unwrap_owner.rs
+++ b/examples/try_unwrap_owner.rs
@@ -1,0 +1,7 @@
+use anybytes::Bytes;
+
+fn main() {
+    let bytes = Bytes::from(vec![1u8, 2, 3]);
+    let original = bytes.try_unwrap_owner::<Vec<u8>>().expect("unique owner");
+    assert_eq!(original, vec![1, 2, 3]);
+}


### PR DESCRIPTION
## Summary
- document how `Bytes::try_unwrap_owner` can reclaim the owner when uniquely held
- link to a new `examples/try_unwrap_owner.rs`

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_687ed84a9d4483229f1b1a592f7f3aba