### PR TITLE
Remove outdated inventory items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - added README example demonstrating `Bytes::try_unwrap_owner`
 - expanded `ByteOwner` trait docs to clarify lifetime requirements and trait
   upcasting for downcasting
+- removed rope-like store integration and async wrappers from the inventory
 
 ## 0.19.3 - 2025-05-30
 - implemented `Error` for `ViewError`

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -4,8 +4,7 @@
 - None at the moment.
 
 ## Desired Functionality
-- Add ByteSource integration for rope-like stores.
-- Provide asynchronous-friendly wrappers without forcing async code in the core.
+- None at the moment.
 
 ## Discovered Issues
 - None at the moment.


### PR DESCRIPTION
## Summary
- clean up `INVENTORY.md` by removing obsolete tasks
- note removal in the changelog

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_687fcff51c248322acfdabd5892616c9