### PR TITLE
Document Arc source usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@
 - removed the unsafe derive macro idea from the inventory
 - removed the `Iterator` support idea from the inventory as `Bytes` already
   dereferences to `[u8]`
+- documented creating `Bytes` from `Arc` sources without an extra wrapper and
+  removed the corresponding task from the inventory
 
 ## 0.19.3 - 2025-05-30
 - implemented `Error` for `ViewError`

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -4,10 +4,6 @@
 - None at the moment.
 
 ## Desired Functionality
-- Document that `Bytes::from(Arc<Vec<u8>>)` and similar constructors already
-  handle owning `Arc` types without an extra wrapper. Implementing
-  `ByteSource` for `Arc<[u8]>` or `Arc<Vec<u8>>` would double-wrap the arc and is
-  therefore unnecessary.
 - Helper `map_file_region` to map only part of a file.
 - Example demonstrating Python + winnow parsing.
 - Additional Kani proofs covering `try_unwrap_owner` and weak references.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,23 @@ fn main() {
 
 The full example is available in [`examples/quick_start.rs`](examples/quick_start.rs).
 
+## Arc Sources
+
+`Bytes` can also be created directly from an `Arc` holding a byte container.
+This avoids allocating another `Arc` wrapper:
+
+```rust
+use anybytes::Bytes;
+use std::sync::Arc;
+
+let data = Arc::new(vec![1u8, 2, 3, 4]);
+let bytes = Bytes::from(data.clone());
+assert_eq!(bytes.as_ref(), data.as_slice());
+```
+
+Implementing `ByteSource` for `Arc<[u8]>` or `Arc<Vec<u8>>` is therefore
+unnecessary, since `Bytes::from` already reuses the provided `Arc`.
+
 ## Reclaiming Ownership
 
 `Bytes::try_unwrap_owner` allows recovering the original owner when no other

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -396,6 +396,12 @@ impl<T: ByteSource> From<T> for Bytes {
     }
 }
 
+/// Creates `Bytes` directly from an [`Arc`] containing the source.
+///
+/// This reuses the provided `Arc` as the owner so there is no extra
+/// allocation. Common containers like `Arc<Vec<u8>>` therefore work
+/// out of the box without needing a special wrapper type or an
+/// additional `ByteSource` implementation.
 impl<T: ByteSource + ByteOwner> From<Arc<T>> for Bytes {
     fn from(arc: Arc<T>) -> Self {
         Self::from_owning_source_arc(arc)


### PR DESCRIPTION
## Summary
- document that `Bytes::from(Arc<T>)` uses the provided Arc without wrapping
- add README section showing Arc sources
- remove the inventory entry requesting this doc

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_688035d3dd4c8322a8725cadf2215449