### PR TITLE
Implement Bytes integration with bytes crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@
   dereferences to `[u8]`
 - documented creating `Bytes` from `Arc` sources without an extra wrapper and
   removed the corresponding task from the inventory
+- implemented `bytes::Buf` for `Bytes` and `From<Bytes>` for `bytes::Bytes` for
+  seamless integration with Tokio and other libraries
 
 ## 0.19.3 - 2025-05-30
 - implemented `Error` for `ViewError`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anybytes"
-version = "0.19.3"
+version = "0.19.4"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/triblespace/anybytes"

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -433,6 +433,13 @@ impl<T: ByteSource + ByteOwner> From<Arc<T>> for Bytes {
     }
 }
 
+#[cfg(feature = "bytes")]
+impl From<Bytes> for bytes::Bytes {
+    fn from(bytes: Bytes) -> Self {
+        bytes::Bytes::from_owner(bytes)
+    }
+}
+
 impl Deref for Bytes {
     type Target = [u8];
     #[inline]
@@ -498,6 +505,27 @@ impl fmt::Debug for Bytes {
         }
         f.write_str("\"")?;
         Ok(())
+    }
+}
+
+#[cfg(feature = "bytes")]
+impl bytes::Buf for Bytes {
+    #[inline]
+    fn remaining(&self) -> usize {
+        self.data.len()
+    }
+
+    #[inline]
+    fn chunk(&self) -> &[u8] {
+        self.data
+    }
+
+    #[inline]
+    fn advance(&mut self, cnt: usize) {
+        if cnt > self.data.len() {
+            panic!("advance out of bounds: {} > {}", cnt, self.data.len());
+        }
+        self.data = &self.data[cnt..];
     }
 }
 


### PR DESCRIPTION
## Summary
- implement `bytes::Buf` for `Bytes`
- allow converting our `Bytes` to `bytes::Bytes`
- document integration
- bump version to 0.19.4

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_68816f07ce748322aa723358c22ac0dd