### PR TITLE
Add zerocopy push for ByteBuffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - install `rustfmt` and the Kani verifier automatically via `cargo install`
 - restore Kani proof best practices in `AGENTS.md` and note that proofs run via `verify.sh`
 - limit Kani loop unwind by default and set per-harness bounds
+- `ByteBuffer::push` now accepts any `IntoBytes + Immutable` value when the
+  `zerocopy` feature is enabled
 - increase unwind for prefix/suffix overflow proofs
 - move weak reference and downcasting examples into module docs
 - expand module introduction describing use cases

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -308,9 +308,9 @@ fn test_bytebuffer_push_and_bytes() {
     use crate::ByteBuffer;
 
     let mut buf: ByteBuffer<8> = ByteBuffer::with_capacity(2);
-    buf.push(1);
-    buf.push(2);
-    buf.push(3);
+    buf.push(1u8);
+    buf.push(2u8);
+    buf.push(3u8);
     assert_eq!(buf.as_ref(), &[1, 2, 3]);
 
     let bytes: Bytes = buf.into();
@@ -322,7 +322,7 @@ fn test_bytebuffer_alignment() {
     use crate::ByteBuffer;
 
     let mut buf: ByteBuffer<64> = ByteBuffer::with_capacity(1);
-    buf.push(1);
+    buf.push(1u8);
     assert_eq!((buf.as_ptr() as usize) % 64, 0);
 }
 
@@ -334,7 +334,7 @@ fn test_bytebuffer_reserve_total() {
     buf.reserve_total(10);
     assert!(buf.capacity() >= 10);
     for _ in 0..10 {
-        buf.push(1);
+        buf.push(1u8);
     }
     assert_eq!(buf.len(), 10);
     assert!(buf.capacity() >= 10);


### PR DESCRIPTION
## Summary
- support pushing `IntoBytes` data in `ByteBuffer` when the `zerocopy` feature is on
- tag numeric literals in tests as `u8`
- document the new capability

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_6884b991f8548322a54ac9d05f084b86