### PR TITLE
Refactor ByteArena into ByteArea with SectionWriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
 ## Unreleased
-- added `ByteArea` for staged file writes with `Section::finish()` to return `Bytes`
+- added `ByteArea` for staged file writes with `Section::freeze()` to return `Bytes`
 - `SectionWriter::reserve` now accepts a zerocopy type instead of an alignment constant
 - `ByteArea` reuses previous pages so allocations align only to the element type
-- `Section::finish` converts the writable mapping to read-only instead of remapping
+- `Section::freeze` converts the writable mapping to read-only instead of remapping
 - simplified `ByteArea` by introducing `SectionWriter` for mutable access without
   interior mutability
 - tie `Section` lifetime to `ByteArea` to prevent dangling sections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - compile-time assertion that `ALIGN` is a power of two
 - added `reserve_total` to `ByteBuffer` for reserving absolute capacity
 - fixed potential UB in `Bytes::try_unwrap_owner` for custom owners
+- renamed `ByteArea::writer` to `sections` for clarity
 - prevent dangling `data` by dropping references before unwrapping the owner
 - refined `Bytes::try_unwrap_owner` to cast the data slice to a pointer only
   when the owner type matches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,19 @@
 # Changelog
 
 ## Unreleased
-- added `ByteArena` for staged file writes with `Buffer::finish()` to return `Bytes`
-- `ByteArena::write` now accepts a zerocopy type instead of an alignment constant
-- `ByteArena` reuses previous pages so allocations align only to the element type
-- `Buffer::finish` converts the writable mapping to read-only instead of remapping
-- documented all fields in `ByteArena` and `Buffer`
-- documented ByteArena usage under advanced usage with proper heading
-- added `ByteArena::persist` to rename the temporary file
-- removed the old `ByteBuffer` type in favor of `ByteArena`
-- added tests covering `ByteArena` writes, typed buffers and persistence
+- added `ByteArea` for staged file writes with `Section::finish()` to return `Bytes`
+- `SectionWriter::reserve` now accepts a zerocopy type instead of an alignment constant
+- `ByteArea` reuses previous pages so allocations align only to the element type
+- `Section::finish` converts the writable mapping to read-only instead of remapping
+- simplified `ByteArea` by introducing `SectionWriter` for mutable access without
+  interior mutability
+- tie `Section` lifetime to `ByteArea` to prevent dangling sections
+- allow multiple `ByteArea` sections at once with non-overlapping byte ranges
+- documented all fields in `ByteArea`, `SectionWriter` and `Section`
+- documented ByteArea usage under advanced usage with proper heading
+- added `ByteArea::persist` to rename the temporary file
+- removed the old `ByteBuffer` type in favor of `ByteArea`
+- added tests covering `ByteArea` sections, typed reserves and persistence
 - added test verifying alignment padding between differently aligned writes
 - split Kani verification into `verify.sh` and streamline `preflight.sh`
 - clarify that `verify.sh` runs on a dedicated system and document avoiding async code

--- a/README.md
+++ b/README.md
@@ -101,26 +101,29 @@ fn read_header(file: &std::fs::File) -> std::io::Result<anybytes::view::View<Hea
 To map only a portion of a file use the unsafe helper
 `Bytes::map_file_region(file, offset, len)`.
 
-### Byte Arena
+### Byte Area
 
-Use `ByteArena` to incrementally build immutable bytes on disk:
+Use `ByteArea` to incrementally build immutable bytes on disk:
 
 ```rust
-use anybytes::arena::ByteArena;
+use anybytes::area::ByteArea;
 
-let mut arena = ByteArena::new().unwrap();
-let mut buffer = arena.write::<u8>(4).unwrap();
-buffer.copy_from_slice(b"test");
-let bytes = buffer.finish().unwrap();
+let mut area = ByteArea::new().unwrap();
+let mut writer = area.writer();
+let mut section = writer.reserve::<u8>(4).unwrap();
+section.copy_from_slice(b"test");
+let bytes = section.finish().unwrap();
 assert_eq!(bytes.as_ref(), b"test".as_ref());
-let all = arena.finish().unwrap();
+drop(writer);
+let all = area.finish().unwrap();
 assert_eq!(all.as_ref(), b"test".as_ref());
 ```
 
-Call `arena.persist(path)` to keep the temporary file instead of mapping it.
+Call `area.persist(path)` to keep the temporary file instead of mapping it.
 
-The arena only aligns allocations to the element type and may share pages
-between adjacent buffers to minimize wasted space.
+The area only aligns allocations to the element type and may share pages
+between adjacent sections to minimize wasted space. Multiple sections may be
+active simultaneously; their byte ranges do not overlap.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -109,12 +109,12 @@ Use `ByteArea` to incrementally build immutable bytes on disk:
 use anybytes::area::ByteArea;
 
 let mut area = ByteArea::new().unwrap();
-let mut writer = area.writer();
-let mut section = writer.reserve::<u8>(4).unwrap();
+let mut sections = area.sections();
+let mut section = sections.reserve::<u8>(4).unwrap();
 section.copy_from_slice(b"test");
 let bytes = section.freeze().unwrap();
 assert_eq!(bytes.as_ref(), b"test".as_ref());
-drop(writer);
+drop(sections);
 let all = area.freeze().unwrap();
 assert_eq!(all.as_ref(), b"test".as_ref());
 ```

--- a/README.md
+++ b/README.md
@@ -112,10 +112,10 @@ let mut area = ByteArea::new().unwrap();
 let mut writer = area.writer();
 let mut section = writer.reserve::<u8>(4).unwrap();
 section.copy_from_slice(b"test");
-let bytes = section.finish().unwrap();
+let bytes = section.freeze().unwrap();
 assert_eq!(bytes.as_ref(), b"test".as_ref());
 drop(writer);
-let all = area.finish().unwrap();
+let all = area.freeze().unwrap();
 assert_eq!(all.as_ref(), b"test".as_ref());
 ```
 

--- a/src/area.rs
+++ b/src/area.rs
@@ -6,13 +6,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//! Temporary byte arena backed by a file.
+//! Temporary byte area backed by a file.
 //!
-//! The arena allows staged writing through [`ByteArena::write`]. Each
-//! call returns a mutable [`Buffer`] bound to the arena so only one
-//! writer can exist at a time. Finalizing the buffer via
-//! [`Buffer::finish`] remaps the written range as immutable and
-//! returns [`Bytes`].
+//! The area offers staged writing through a [`SectionWriter`]. Each call to
+//! [`SectionWriter::reserve`] returns a mutable [`Section`] tied to the area's
+//! lifetime. Multiple sections may coexist; their byte ranges do not overlap.
+//! Finalizing a section via [`Section::finish`] remaps its range as immutable
+//! and returns [`Bytes`].
 
 use std::io::{self, Seek, SeekFrom};
 use std::marker::PhantomData;
@@ -31,93 +31,98 @@ fn align_up(val: usize, align: usize) -> usize {
     (val + align - 1) & !(align - 1)
 }
 
-/// Arena managing a temporary file.
+/// Area managing a temporary file.
 #[derive(Debug)]
-pub struct ByteArena {
-    /// Temporary file backing the arena.
+pub struct ByteArea {
+    /// Temporary file backing the area.
     file: NamedTempFile,
     /// Current length of initialized data in bytes.
     len: usize,
 }
 
-impl ByteArena {
-    /// Create a new empty arena.
+impl ByteArea {
+    /// Create a new empty area.
     pub fn new() -> io::Result<Self> {
         let file = NamedTempFile::new()?;
         Ok(Self { file, len: 0 })
     }
 
-    /// Start a new write of `elems` elements of type `T`.
-    pub fn write<'a, T>(&'a mut self, elems: usize) -> io::Result<Buffer<'a, T>>
-    where
-        T: FromBytes + Immutable,
-    {
-        let page = page_size::get();
-        let align = core::mem::align_of::<T>();
-        let len_bytes = core::mem::size_of::<T>() * elems;
-        let start = align_up(self.len, align);
-        let end = start + len_bytes;
-        self.file.as_file_mut().set_len(end as u64)?;
-        // Ensure subsequent mappings see the extended size.
-        self.file.as_file_mut().seek(SeekFrom::Start(end as u64))?;
-
-        // Map must start on a page boundary; round `start` down while
-        // keeping track of how far into the mapping the buffer begins.
-        let aligned_offset = start & !(page - 1);
-        let offset = start - aligned_offset;
-        let map_len = end - aligned_offset;
-
-        let mmap = unsafe {
-            memmap2::MmapOptions::new()
-                .offset(aligned_offset as u64)
-                .len(map_len)
-                .map_mut(self.file.as_file())?
-        };
-        Ok(Buffer {
-            arena: self,
-            mmap,
-            start,
-            offset,
-            elems,
-            _marker: PhantomData,
-        })
+    /// Obtain a writer for reserving sections.
+    pub fn writer(&mut self) -> SectionWriter<'_> {
+        SectionWriter { area: self }
     }
 
-    fn update_len(&mut self, end: usize) {
-        self.len = end;
-    }
-
-    /// Finalize the arena and return immutable bytes for the entire file.
+    /// Finalize the area and return immutable bytes for the entire file.
     pub fn finish(self) -> io::Result<Bytes> {
         let file = self.file.into_file();
         let mmap = unsafe { memmap2::MmapOptions::new().map(&file)? };
         Ok(Bytes::from_source(mmap))
     }
 
-    /// Persist the temporary arena file to `path` and return the underlying [`File`].
+    /// Persist the temporary area file to `path` and return the underlying [`File`].
     pub fn persist<P: AsRef<std::path::Path>>(self, path: P) -> io::Result<std::fs::File> {
         self.file.persist(path).map_err(Into::into)
     }
 }
 
-/// Mutable buffer for writing into a [`ByteArena`].
+/// RAII guard giving temporary exclusive write access.
 #[derive(Debug)]
-pub struct Buffer<'a, T> {
-    /// Arena that owns the underlying file.
-    arena: &'a mut ByteArena,
+pub struct SectionWriter<'area> {
+    area: &'area mut ByteArea,
+}
+
+impl<'area> SectionWriter<'area> {
+    /// Reserve a new section inside the area.
+    pub fn reserve<T>(&mut self, elems: usize) -> io::Result<Section<'area, T>>
+    where
+        T: FromBytes + Immutable,
+    {
+        let page = page_size::get();
+        let align = core::mem::align_of::<T>();
+        let len_bytes = core::mem::size_of::<T>() * elems;
+        let start = align_up(self.area.len, align);
+        let end = start + len_bytes;
+
+        let aligned_offset = start & !(page - 1);
+        let offset = start - aligned_offset;
+        let map_len = end - aligned_offset;
+
+        let file = &mut self.area.file;
+        file.as_file_mut().set_len(end as u64)?;
+        // Ensure subsequent mappings see the extended size.
+        file.as_file_mut().seek(SeekFrom::Start(end as u64))?;
+        let mmap = unsafe {
+            memmap2::MmapOptions::new()
+                .offset(aligned_offset as u64)
+                .len(map_len)
+                .map_mut(file.as_file())?
+        };
+
+        self.area.len = end;
+
+        Ok(Section {
+            mmap,
+            offset,
+            elems,
+            _marker: PhantomData,
+        })
+    }
+}
+
+/// Mutable section reserved from a [`ByteArea`].
+#[derive(Debug)]
+pub struct Section<'arena, T> {
     /// Writable mapping for the current allocation.
     mmap: memmap2::MmapMut,
-    /// Start position of this buffer within the arena file in bytes.
-    start: usize,
     /// Offset from the beginning of `mmap` to the start of the buffer.
     offset: usize,
     /// Number of elements in the buffer.
     elems: usize,
-    /// Marker to tie the buffer to element type `T`.
-    _marker: PhantomData<T>,
+    /// Marker tying the section to the area and element type.
+    _marker: PhantomData<(&'arena ByteArea, *mut T)>,
 }
 
-impl<'a, T> Buffer<'a, T>
+impl<'arena, T> Section<'arena, T>
 where
     T: FromBytes + Immutable,
 {
@@ -129,21 +134,19 @@ where
         }
     }
 
-    /// Finalize the buffer and return immutable [`Bytes`].
+    /// Finalize the section and return immutable [`Bytes`].
     pub fn finish(self) -> io::Result<Bytes> {
         self.mmap.flush()?;
         let len_bytes = self.elems * core::mem::size_of::<T>();
         let offset = self.offset;
-        let arena = self.arena;
         // Convert the writable mapping into a read-only view instead of
         // unmapping and remapping the region.
         let map = self.mmap.make_read_only()?;
-        arena.update_len(self.start + len_bytes);
         Ok(Bytes::from_source(map).slice(offset..offset + len_bytes))
     }
 }
 
-impl<'a, T> core::ops::Deref for Buffer<'a, T>
+impl<'arena, T> core::ops::Deref for Section<'arena, T>
 where
     T: FromBytes + Immutable,
 {
@@ -157,7 +160,7 @@ where
     }
 }
 
-impl<'a, T> core::ops::DerefMut for Buffer<'a, T>
+impl<'arena, T> core::ops::DerefMut for Section<'arena, T>
 where
     T: FromBytes + Immutable,
 {
@@ -169,7 +172,7 @@ where
     }
 }
 
-impl<'a, T> AsRef<[T]> for Buffer<'a, T>
+impl<'arena, T> AsRef<[T]> for Section<'arena, T>
 where
     T: FromBytes + Immutable,
 {
@@ -178,7 +181,7 @@ where
     }
 }
 
-impl<'a, T> AsMut<[T]> for Buffer<'a, T>
+impl<'arena, T> AsMut<[T]> for Section<'arena, T>
 where
     T: FromBytes + Immutable,
 {

--- a/src/area.rs
+++ b/src/area.rs
@@ -11,8 +11,8 @@
 //! The area offers staged writing through a [`SectionWriter`]. Each call to
 //! [`SectionWriter::reserve`] returns a mutable [`Section`] tied to the area's
 //! lifetime. Multiple sections may coexist; their byte ranges do not overlap.
-//! Finalizing a section via [`Section::finish`] remaps its range as immutable
-//! and returns [`Bytes`].
+//! Freezing a section via [`Section::freeze`] remaps its range as immutable and
+//! returns [`Bytes`].
 
 use std::io::{self, Seek, SeekFrom};
 use std::marker::PhantomData;
@@ -52,8 +52,8 @@ impl ByteArea {
         SectionWriter { area: self }
     }
 
-    /// Finalize the area and return immutable bytes for the entire file.
-    pub fn finish(self) -> io::Result<Bytes> {
+    /// Freeze the area and return immutable bytes for the entire file.
+    pub fn freeze(self) -> io::Result<Bytes> {
         let file = self.file.into_file();
         let mmap = unsafe { memmap2::MmapOptions::new().map(&file)? };
         Ok(Bytes::from_source(mmap))
@@ -134,8 +134,8 @@ where
         }
     }
 
-    /// Finalize the section and return immutable [`Bytes`].
-    pub fn finish(self) -> io::Result<Bytes> {
+    /// Freeze the section and return immutable [`Bytes`].
+    pub fn freeze(self) -> io::Result<Bytes> {
         self.mmap.flush()?;
         let len_bytes = self.elems * core::mem::size_of::<T>();
         let offset = self.offset;

--- a/src/area.rs
+++ b/src/area.rs
@@ -47,8 +47,8 @@ impl ByteArea {
         Ok(Self { file, len: 0 })
     }
 
-    /// Obtain a writer for reserving sections.
-    pub fn writer(&mut self) -> SectionWriter<'_> {
+    /// Obtain a handle for reserving sections.
+    pub fn sections(&mut self) -> SectionWriter<'_> {
         SectionWriter { area: self }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 #![warn(missing_docs)]
 
 #[cfg(all(feature = "mmap", feature = "zerocopy"))]
-pub mod arena;
+pub mod area;
 /// Core byte container types and traits.
 pub mod bytes;
 mod sources;
@@ -31,7 +31,7 @@ pub mod winnow;
 mod tests;
 
 #[cfg(all(feature = "mmap", feature = "zerocopy"))]
-pub use crate::arena::{Buffer, ByteArena};
+pub use crate::area::{ByteArea, Section, SectionWriter};
 pub use crate::bytes::ByteOwner;
 pub use crate::bytes::ByteSource;
 pub use crate::bytes::Bytes;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -313,11 +313,11 @@ fn test_area_single_reserve() {
         let mut writer = area.writer();
         let mut section = writer.reserve::<u8>(4).expect("reserve");
         section.as_mut_slice().copy_from_slice(b"test");
-        let bytes = section.finish().expect("finish section");
+        let bytes = section.freeze().expect("freeze section");
         assert_eq!(bytes.as_ref(), b"test");
     }
 
-    let all = area.finish().expect("finish area");
+    let all = area.freeze().expect("freeze area");
     assert_eq!(all.as_ref(), b"test");
 }
 
@@ -332,16 +332,16 @@ fn test_area_multiple_reserves() {
 
         let mut a = writer.reserve::<u8>(5).expect("reserve");
         a.as_mut_slice().copy_from_slice(b"first");
-        let bytes_a = a.finish().expect("finish");
+        let bytes_a = a.freeze().expect("freeze");
         assert_eq!(bytes_a.as_ref(), b"first");
 
         let mut b = writer.reserve::<u8>(6).expect("reserve");
         b.as_mut_slice().copy_from_slice(b"second");
-        let bytes_b = b.finish().expect("finish");
+        let bytes_b = b.freeze().expect("freeze");
         assert_eq!(bytes_b.as_ref(), b"second");
     }
 
-    let all = area.finish().expect("finish area");
+    let all = area.freeze().expect("freeze area");
     assert_eq!(all.as_ref(), b"firstsecond");
 }
 
@@ -358,14 +358,14 @@ fn test_area_concurrent_sections() {
     a.as_mut_slice().copy_from_slice(b"first");
     b.as_mut_slice().copy_from_slice(b"second");
 
-    let bytes_b = b.finish().expect("finish b");
-    let bytes_a = a.finish().expect("finish a");
+    let bytes_b = b.freeze().expect("freeze b");
+    let bytes_a = a.freeze().expect("freeze a");
 
     assert_eq!(bytes_a.as_ref(), b"first");
     assert_eq!(bytes_b.as_ref(), b"second");
 
     drop(writer);
-    let all = area.finish().expect("finish area");
+    let all = area.freeze().expect("freeze area");
     assert_eq!(all.as_ref(), b"firstsecond");
 }
 
@@ -387,7 +387,7 @@ fn test_area_typed() {
         let mut section = writer.reserve::<Pair>(2).expect("reserve");
         section.as_mut_slice()[0] = Pair { a: 1, b: 2 };
         section.as_mut_slice()[1] = Pair { a: 3, b: 4 };
-        section.finish().expect("finish")
+        section.freeze().expect("freeze")
     };
 
     let expected = unsafe {
@@ -413,7 +413,7 @@ fn test_area_persist() {
         let mut writer = area.writer();
         let mut section = writer.reserve::<u8>(7).expect("reserve");
         section.as_mut_slice().copy_from_slice(b"persist");
-        section.finish().expect("finish section");
+        section.freeze().expect("freeze section");
     }
 
     let _file = area.persist(&path).expect("persist file");
@@ -432,21 +432,21 @@ fn test_area_alignment_padding() {
 
         let mut a = writer.reserve::<u8>(1).expect("reserve");
         a.as_mut_slice()[0] = 1;
-        let bytes_a = a.finish().expect("finish a");
+        let bytes_a = a.freeze().expect("freeze a");
         assert_eq!(bytes_a.as_ref(), &[1]);
 
         let mut b = writer.reserve::<u32>(1).expect("reserve");
         b.as_mut_slice()[0] = 0x01020304;
-        let bytes_b = b.finish().expect("finish b");
+        let bytes_b = b.freeze().expect("freeze b");
         assert_eq!(bytes_b.as_ref(), &0x01020304u32.to_ne_bytes());
 
         let mut c = writer.reserve::<u16>(1).expect("reserve");
         c.as_mut_slice()[0] = 0x0506;
-        let bytes_c = c.finish().expect("finish c");
+        let bytes_c = c.freeze().expect("freeze c");
         assert_eq!(bytes_c.as_ref(), &0x0506u16.to_ne_bytes());
     }
 
-    let all = area.finish().expect("finish area");
+    let all = area.freeze().expect("freeze area");
 
     let mut expected = Vec::new();
     expected.extend_from_slice(&[1]);


### PR DESCRIPTION
## Summary
- rename `ByteArena` to `ByteArea`
- add `SectionWriter`/`Section` API to reserve multiple non-overlapping sections without interior mutability
- document and test that multiple sections can coexist with non-overlapping byte ranges

## Testing
- `./scripts/devtest.sh`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_688a6284a3b88322bc40d153388fd35e