### PR TITLE
Add tests for pop helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - documented safety rationale for `winnow` integration
 - implemented `Stream` directly for `Bytes` with a safe `iter_offsets` iterator
 - added `pop_back` and `pop_front` helpers and rewrote parser examples
+- added tests covering `pop_front` and `pop_back`
 - removed the Completed Work section from `INVENTORY.md` and documented its use
 - added `Bytes::try_unwrap_owner` to reclaim the owner when uniquely held
 - simplified `Bytes::try_unwrap_owner` implementation

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -9,4 +9,4 @@
 - `ByteSource` implementation for `VecDeque<u8>` to support ring buffers.
 
 ## Discovered Issues
-- Missing tests for `pop_front` and `pop_back` helpers.
+- None at the moment.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -104,6 +104,26 @@ fn test_slice_to_bytes_unrelated_slice() {
 }
 
 #[test]
+fn test_pop_front() {
+    let mut bytes = Bytes::from(b"abc".to_vec());
+    assert_eq!(bytes.pop_front(), Some(b'a'));
+    assert_eq!(bytes.as_ref(), b"bc");
+    assert_eq!(bytes.pop_front(), Some(b'b'));
+    assert_eq!(bytes.pop_front(), Some(b'c'));
+    assert_eq!(bytes.pop_front(), None);
+}
+
+#[test]
+fn test_pop_back() {
+    let mut bytes = Bytes::from(b"abc".to_vec());
+    assert_eq!(bytes.pop_back(), Some(b'c'));
+    assert_eq!(bytes.as_ref(), b"ab");
+    assert_eq!(bytes.pop_back(), Some(b'b'));
+    assert_eq!(bytes.pop_back(), Some(b'a'));
+    assert_eq!(bytes.pop_back(), None);
+}
+
+#[test]
 fn test_weakbytes_multiple_upgrades() {
     let bytes = Bytes::from(b"hello".to_vec());
     let weak = bytes.downgrade();


### PR DESCRIPTION
## Summary
- test `Bytes::pop_front` and `Bytes::pop_back`
- record resolved issue in `INVENTORY`

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_688de1a49c908322b8992a9ba64f8baf