### PR TITLE
Add VecDeque ByteSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- added `ByteSource` support for `VecDeque<T>` when `zerocopy` is enabled and kept the deque as owner
 - added `ByteSource` support for `Cow<'static, T>` where `T: AsRef<[u8]>`
 - added `ByteArea` for staged file writes with `Section::freeze()` to return `Bytes`
 - `SectionWriter::reserve` now accepts a zerocopy type instead of an alignment constant

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -5,7 +5,6 @@
 
 ## Desired Functionality
 - Example demonstrating Python + winnow parsing.
-- `ByteSource` implementation for `VecDeque<u8>` to support ring buffers.
-
+ 
 ## Discovered Issues
 - None at the moment.


### PR DESCRIPTION
## Summary
- support `VecDeque<T>` as a ByteSource when the `zerocopy` feature is enabled
- use the deque itself as owner to uphold the `ByteSource` contract
- test `VecDeque` handling, including generic types and the panic on non-contiguous buffers
- document `VecDeque` integration and note the feature requirement

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e0e634ae4832296ce5152cd0da9dd