### PR TITLE
Add Python winnow parsing example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- added example combining Python bindings with winnow parsing
 - added `ByteSource` support for `VecDeque<T>` when `zerocopy` is enabled and kept the deque as owner
 - added `ByteSource` support for `Cow<'static, T>` where `T: AsRef<[u8]>`
 - added `ByteArea` for staged file writes with `Section::freeze()` to return `Bytes`

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -4,7 +4,7 @@
 - None at the moment.
 
 ## Desired Functionality
-- Example demonstrating Python + winnow parsing.
- 
+- Python example using winnow::view to parse structured data.
+
 ## Discovered Issues
 - None at the moment.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ needs these libraries installed; otherwise disable the feature during testing.
 - [`examples/try_unwrap_owner.rs`](examples/try_unwrap_owner.rs) – reclaim the owner when uniquely referenced
 - [`examples/pybytes.rs`](examples/pybytes.rs) – demonstrates the `pyo3` feature using `PyBytes`
 - [`examples/from_python.rs`](examples/from_python.rs) – wrap a Python `bytes` object into `Bytes`
+- [`examples/python_winnow.rs`](examples/python_winnow.rs) – parse Python bytes with winnow
 
 ## Comparison
 

--- a/examples/python_winnow.rs
+++ b/examples/python_winnow.rs
@@ -1,0 +1,19 @@
+#![cfg(all(feature = "pyo3", feature = "winnow"))]
+
+use anybytes::Bytes;
+use pyo3::{prelude::*, types::PyBytes};
+use winnow::{error::ContextError, stream::AsBytes, token::take, Parser};
+
+fn main() -> PyResult<()> {
+    Python::with_gil(|py| {
+        let obj = PyBytes::new(py, b"abcde");
+        let mut bytes = Bytes::from_source(obj);
+
+        // Take the first three bytes using a winnow parser
+        let mut parser = take::<_, _, ContextError>(3usize);
+        let prefix: Bytes = parser.parse_next(&mut bytes).expect("take");
+        assert_eq!(prefix.as_bytes(), b"abc".as_ref());
+        assert_eq!(bytes.as_bytes(), b"de".as_ref());
+        Ok(())
+    })
+}


### PR DESCRIPTION
## Summary
- add example combining Python bindings with winnow parsing
- document the new example in the README and changelog
- note future structured parsing example in the inventory

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e164f1bb4832294cc4d1206035057