### PR TITLE
Add tests for prefix and suffix helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - implemented `Stream` directly for `Bytes` with a safe `iter_offsets` iterator
 - added `pop_back` and `pop_front` helpers and rewrote parser examples
 - added tests covering `pop_front` and `pop_back`
+- added tests covering `take_prefix` and `take_suffix`
 - removed the Completed Work section from `INVENTORY.md` and documented its use
 - added `Bytes::try_unwrap_owner` to reclaim the owner when uniquely held
 - simplified `Bytes::try_unwrap_owner` implementation

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -5,6 +5,7 @@
 
 ## Desired Functionality
 - Add Kani proofs for winnow view helpers.
+- Implement `ExactSizeIterator` or `FusedIterator` for `BytesIterOffsets` to simplify iteration.
 
 ## Discovered Issues
 - None at the moment.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -175,6 +175,24 @@ fn test_pop_back() {
 }
 
 #[test]
+fn test_take_prefix() {
+    let mut bytes = Bytes::from(b"abcdef".to_vec());
+    let prefix = bytes.take_prefix(2).expect("prefix");
+    assert_eq!(prefix.as_ref(), b"ab");
+    assert_eq!(bytes.as_ref(), b"cdef");
+    assert!(bytes.take_prefix(10).is_none());
+}
+
+#[test]
+fn test_take_suffix() {
+    let mut bytes = Bytes::from(b"abcdef".to_vec());
+    let suffix = bytes.take_suffix(2).expect("suffix");
+    assert_eq!(suffix.as_ref(), b"ef");
+    assert_eq!(bytes.as_ref(), b"abcd");
+    assert!(bytes.take_suffix(10).is_none());
+}
+
+#[test]
 fn test_weakbytes_multiple_upgrades() {
     let bytes = Bytes::from(b"hello".to_vec());
     let weak = bytes.downgrade();


### PR DESCRIPTION
## Summary
- test take_prefix and take_suffix to ensure they split data correctly
- record potential iterator enhancements for BytesIterOffsets in the inventory

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e2a8c36e0832283b451897b431d9b