### PR TITLE
Implement iterator traits for BytesIterOffsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@
   removed the corresponding task from the inventory
 - implemented `bytes::Buf` for `Bytes` and `From<Bytes>` for `bytes::Bytes` for
   seamless integration with Tokio and other libraries
+- implemented `ExactSizeIterator` and `FusedIterator` for `BytesIterOffsets`
 
 ## 0.19.3 - 2025-05-30
 - implemented `Error` for `ViewError`

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -5,7 +5,6 @@
 
 ## Desired Functionality
 - Add Kani proofs for winnow view helpers.
-- Implement `ExactSizeIterator` or `FusedIterator` for `BytesIterOffsets` to simplify iteration.
 
 ## Discovered Issues
 - None at the moment.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -281,6 +281,31 @@ fn test_winnow_stream_take() {
     assert_eq!(input.as_bytes(), [3u8, 4].as_ref());
 }
 
+#[cfg(feature = "winnow")]
+#[test]
+fn test_iter_offsets_traits() {
+    use std::iter::{ExactSizeIterator, FusedIterator};
+    use winnow::stream::Stream;
+
+    fn assert_traits<I: ExactSizeIterator + FusedIterator>(iter: I) -> I {
+        iter
+    }
+
+    let bytes = Bytes::from(vec![1u8, 2, 3, 4]);
+    let mut iter = assert_traits(Stream::iter_offsets(&bytes));
+    assert_eq!(iter.len(), 4);
+    assert_eq!(iter.size_hint(), (4, Some(4)));
+
+    for (i, (offset, byte)) in (&mut iter).enumerate() {
+        assert_eq!(offset, i);
+        assert_eq!(byte, bytes.as_ref()[i]);
+    }
+
+    assert_eq!(iter.len(), 0);
+    assert_eq!(iter.next(), None);
+    assert_eq!(iter.next(), None);
+}
+
 #[cfg(all(feature = "winnow", feature = "zerocopy"))]
 #[test]
 fn test_winnow_view_parser() {

--- a/src/winnow.rs
+++ b/src/winnow.rs
@@ -33,7 +33,20 @@ impl Iterator for BytesIterOffsets {
         self.offset += 1;
         Some((offset, token))
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.bytes.as_slice().len();
+        (len, Some(len))
+    }
 }
+
+impl ExactSizeIterator for BytesIterOffsets {
+    fn len(&self) -> usize {
+        self.bytes.as_slice().len()
+    }
+}
+
+impl std::iter::FusedIterator for BytesIterOffsets {}
 
 impl SliceLen for Bytes {
     #[inline(always)]


### PR DESCRIPTION
## Summary
- implement `size_hint`, `ExactSizeIterator`, and `FusedIterator` for `BytesIterOffsets`
- add unit test ensuring iterator traits and behavior
- document iterator trait implementations in changelog and inventory

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_688e3a3b6fc48322aa2b7bccf5dbfab0