### PR TITLE
Add section handles for ByteArea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - added example demonstrating `ByteArea` with multiple typed sections, concurrent mutations, and freezing or persisting the area
 - added example combining Python bindings with winnow parsing
 - added Python example demonstrating structured parsing with winnow's `view`
+- added `SectionHandle` for reconstructing sections from a frozen `ByteArea`
 - added `ByteSource` support for `VecDeque<T>` when `zerocopy` is enabled and kept the deque as owner
 - added `ByteSource` support for `Cow<'static, T>` where `T: AsRef<[u8]>`
 - added `ByteArea` for staged file writes with `Section::freeze()` to return `Bytes`

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ To map only a portion of a file use the unsafe helper
 
 ### Byte Area
 
-Use `ByteArea` to incrementally build immutable bytes on disk:
+Use `ByteArea` to incrementally build immutable bytes on disk; each section can
+yield a handle that reconstructs its range after the area is frozen:
 
 ```rust
 use anybytes::area::ByteArea;
@@ -112,11 +113,12 @@ let mut area = ByteArea::new().unwrap();
 let mut sections = area.sections();
 let mut section = sections.reserve::<u8>(4).unwrap();
 section.copy_from_slice(b"test");
+let handle = section.handle();
 let bytes = section.freeze().unwrap();
-assert_eq!(bytes.as_ref(), b"test".as_ref());
 drop(sections);
 let all = area.freeze().unwrap();
-assert_eq!(all.as_ref(), b"test".as_ref());
+assert_eq!(handle.bytes(&all).as_ref(), bytes.as_ref());
+assert_eq!(handle.view(&all).unwrap().as_ref(), b"test".as_ref());
 ```
 
 Call `area.persist(path)` to keep the temporary file instead of mapping it.

--- a/examples/byte_area.rs
+++ b/examples/byte_area.rs
@@ -12,6 +12,10 @@ fn main() -> std::io::Result<()> {
     raw.as_mut_slice().copy_from_slice(b"test");
     nums.as_mut_slice().copy_from_slice(&[1, 2]);
 
+    // Store handles so we can later extract the sections from the frozen area.
+    let handle_raw = raw.handle();
+    let handle_nums = nums.handle();
+
     // Freeze the sections into immutable `Bytes`.
     let frozen_raw: Bytes = raw.freeze()?;
     let frozen_nums: Bytes = nums.freeze()?;
@@ -25,8 +29,8 @@ fn main() -> std::io::Result<()> {
     if memory_or_file {
         // Freeze the whole area into immutable `Bytes`.
         let all: Bytes = area.freeze()?;
-        assert_eq!(&all[..4], b"test");
-        assert_eq!(all.slice(4..).view::<[u32]>().unwrap().as_ref(), &[1, 2]);
+        assert_eq!(handle_raw.bytes(&all).as_ref(), frozen_raw.as_ref());
+        assert_eq!(handle_nums.view(&all).unwrap().as_ref(), &[1, 2]);
     } else {
         // Persist the temporary file.
         let dir = tempdir()?;

--- a/tests/area.rs
+++ b/tests/area.rs
@@ -73,3 +73,27 @@ proptest! {
         prop_assert_eq!(all.as_ref(), expected.as_slice());
     }
 }
+
+#[test]
+fn handles_reconstruct_sections() {
+    let mut area = ByteArea::new().expect("area");
+    let mut sections = area.sections();
+
+    let mut a = sections.reserve::<u8>(1).expect("reserve u8");
+    a.as_mut_slice()[0] = 1;
+    let handle_a = a.handle();
+    let bytes_a = a.freeze().expect("freeze a");
+
+    let mut b = sections.reserve::<u32>(1).expect("reserve u32");
+    b.as_mut_slice()[0] = 2;
+    let handle_b = b.handle();
+    let bytes_b = b.freeze().expect("freeze b");
+
+    drop(sections);
+    let all = area.freeze().expect("freeze area");
+
+    assert_eq!(handle_a.bytes(&all).as_ref(), bytes_a.as_ref());
+    assert_eq!(handle_b.bytes(&all).as_ref(), bytes_b.as_ref());
+    assert_eq!(handle_a.view(&all).unwrap().as_ref(), &[1]);
+    assert_eq!(handle_b.view(&all).unwrap().as_ref(), &[2]);
+}


### PR DESCRIPTION
## Summary
- track absolute offsets for sections and expose `SectionHandle` to reconstruct them after freezing a `ByteArea`
- document and demonstrate section handles in README and examples
- test handle-based reconstruction

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_689683dfd92883229c7fa769bacb24e3